### PR TITLE
fix: complete server build with httplib and multimodal support

### DIFF
--- a/build_llama.zig
+++ b/build_llama.zig
@@ -41,6 +41,7 @@ pub const Options = struct {
     build_number: usize = 0, // number that will be writen in build info
     metal_ndebug: bool = false,
     metal_use_bf16: bool = false,
+    httplib: bool = false, // Enable cpp-httplib for remote content fetching
 };
 
 // Build context
@@ -116,6 +117,9 @@ pub const Context = struct {
             }
         }
         ctx.options.backends.addDefines(lib);
+        if (ctx.options.httplib) {
+            lib.root_module.addCMacro("LLAMA_USE_HTTPLIB", "");
+        }
         ctx.addAll(lib);
         if (ctx.options.target.result.abi != .msvc)
             lib.root_module.addCMacro("_GNU_SOURCE", "");


### PR DESCRIPTION
## Summary
- Fixes llama-server build which was failing due to missing source files and dependencies from llama.cpp restructuring

## Changes
- Add `httplib` option to `llama.Context` for remote content fetching (`LLAMA_USE_HTTPLIB`)
- Add all server source files: `server-*.cpp` (context, common, http, models, queue, task)
- Add `cpp-httplib` implementation (`vendor/cpp-httplib/httplib.cpp`)
- Add mtmd (multimodal) core files: `mtmd.cpp`, `mtmd-audio.cpp`, `mtmd-helper.cpp`, `clip.cpp`
- Add all mtmd model implementations (15 models: llava, qwen2vl, pixtral, etc.)
- Add `_USE_MATH_DEFINES` for M_PI on Windows
- Create separate llama context with httplib enabled for server builds

## Testing
- [x] Local Windows build: `zig build -Dserver=true` succeeds
- [x] Local Windows release build: `zig build -Doptimize=ReleaseFast -Dserver=true` succeeds

This PR should fix the release workflow failures for v0.2.0.