### PR TITLE
fix: metal build for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,16 +104,21 @@ jobs:
           gh release upload "${VERSION}" "${ARCHIVE_NAME}.${{ matrix.ext }}" --clobber
 
   # macOS builds with Metal GPU support (requires native runner)
+  # Using native runners and NOT specifying -Dtarget to ensure frameworks are found
   build-macos-metal:
-    name: Build ${{ matrix.target }}-metal
-    runs-on: macos-latest
+    name: Build ${{ matrix.name }}-metal
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-macos
+          # Intel Mac runner for x86_64
+          - runner: macos-13
+            name: x86_64-macos
             arch: x86_64
-          - target: aarch64-macos
+          # ARM Mac runner for aarch64
+          - runner: macos-latest
+            name: aarch64-macos
             arch: arm64
 
     steps:
@@ -127,8 +132,9 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
 
+      # Build WITHOUT -Dtarget to use native target and find frameworks properly
       - name: Build Release with Metal
-        run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }} -Dserver=true -Dmetal=true
+        run: zig build -Doptimize=ReleaseFast -Dserver=true -Dmetal=true
 
       - name: Determine Version
         id: version
@@ -142,7 +148,7 @@ jobs:
       - name: Prepare Archive Directory
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          ARCHIVE_NAME="igllama-${VERSION}-${{ matrix.target }}-metal"
+          ARCHIVE_NAME="igllama-${VERSION}-${{ matrix.name }}-metal"
           mkdir -p "${ARCHIVE_NAME}"
           
           cp zig-out/bin/igllama "${ARCHIVE_NAME}/"

--- a/build_llama.zig
+++ b/build_llama.zig
@@ -280,10 +280,13 @@ pub const Context = struct {
             };
             // Compile the metal shader [requires xcode installed]
             const metal_compile = ctx.b.addSystemCommand(&.{
-                "xcrun", "-sdk", "macosx", "metal", "-fno-fast-math", "-g", "-c", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.metal" }), "-o", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.air" }),
+                "xcrun", "-sdk", "macosx", "metal", "-fno-fast-math", "-g",
+                "-I", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal" }), // Include path for ggml-common.h
+                "-c", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.metal" }),
+                "-o", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.air" }),
             });
             const common_src = ctx.path(&.{ "ggml", "src", "ggml-common.h" });
-            const common_dst = "ggml-common.h";
+            const common_dst = ctx.b.pathJoin(&.{ "metal", "ggml-common.h" }); // Install to metal directory
             const common_install_step = ctx.b.addInstallFile(common_src, common_dst);
             metal_compile.step.dependOn(&common_install_step.step);
             for (metal_files) |file| {


### PR DESCRIPTION
## Summary
- Fix Metal shader compilation by adding `-I` include path for `ggml-common.h`
- Install `ggml-common.h` to `metal/` subdirectory where the shader expects it
- Use native macOS runners instead of cross-compilation for Metal builds:
  - `macos-13` (Intel) for x86_64-macos-metal
  - `macos-latest` (ARM) for aarch64-macos-metal
- Remove `-Dtarget` flag on macOS Metal builds so Zig uses native target and finds system frameworks

## Issues Fixed
1. `'ggml-common.h' file not found` during metal shader compilation
2. `'unable to find framework Foundation/AppKit/Metal/MetalKit'` when Zig cross-compiles with `-Dtarget`

## Root Cause
When Zig is invoked with `-Dtarget=x86_64-macos` or `-Dtarget=aarch64-macos`, even on a native macOS runner, it enters cross-compilation mode and doesn't automatically use the macOS SDK. By using native runners for each architecture and omitting `-Dtarget`, Zig properly detects and links macOS frameworks.