### PR TITLE
fix: use macos-15-intel runner and verify submodule files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Intel Mac runner for x86_64
-          - runner: macos-13
+          # Intel Mac runner for x86_64 (macos-13 retired, using macos-15-intel)
+          - runner: macos-15-intel
             name: x86_64-macos
             arch: x86_64
           # ARM Mac runner for aarch64
@@ -126,6 +126,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Verify Submodule Files
+        run: |
+          # Verify critical submodule files exist
+          ls -la llama.cpp/ggml/src/ggml-metal/ggml-metal.m
+          ls -la llama.cpp/ggml/src/ggml-metal/ggml-metal.metal
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2


### PR DESCRIPTION
## Summary
- Replace retired `macos-13` runner with `macos-15-intel` for x86_64 Metal builds
- Add verification step to confirm submodule files exist before build

## Issue
The release workflow failed because:
1. `macos-13` runner was retired by GitHub
2. There may be a race condition with submodule file access

## Changes
- Use `macos-15-intel` for x86_64-macos-metal builds
- Add a step to verify critical Metal source files exist before building