### PR TITLE
fix: ensure submodule checkout on macOS and remove NetBSD target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,7 @@ jobs:
             ext: tar.gz
           - target: aarch64-freebsd
             ext: tar.gz
-          - target: x86_64-netbsd
-            ext: tar.gz
+
 
     steps:
       - name: Checkout
@@ -126,6 +125,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # Explicit submodule init to work around macOS runner checkout issues
+      - name: Ensure Submodules
+        run: |
+          git submodule update --init --recursive
 
       - name: Verify Submodule Files
         run: |


### PR DESCRIPTION
## Summary
- Add explicit `git submodule update --init --recursive` step after checkout in the macOS Metal build job to work around GitHub Actions macOS runner submodule checkout issues
- Remove NetBSD target from build matrix (llama.cpp does not support NetBSD architecture)

## Problem
The v0.2.0 release had failing builds:
- **macOS Metal builds**: Submodule files (`llama.cpp/ggml/src/ggml-metal/ggml-metal.m`) not found despite `submodules: recursive` in checkout
- **NetBSD build**: `llama.cpp/common/common.cpp:926:4: error: Unknown architecture`

## Changes
1. Added "Ensure Submodules" step in `build-macos-metal` job that runs `git submodule update --init --recursive` explicitly
2. Removed `x86_64-netbsd` entry from the build matrix

## Testing
- Validated with `actionlint` - no errors