### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .igllama,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .paths = .{
         "",
         "src",


### PR DESCRIPTION
## Summary
Update `build.zig.zon` version from 0.1.0 to 0.2.0 to match the released tag.

## Changes
- `build.zig.zon`: `.version = "0.1.0"` -> `.version = "0.2.0"`