### PR TITLE
fix: update metal file check for new llama.cpp structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,8 @@ jobs:
 
       - name: Verify Submodule Files
         run: |
-          # Verify critical submodule files exist
-          ls -la llama.cpp/ggml/src/ggml-metal/ggml-metal.m
+          # Verify critical submodule files exist (file structure changed in recent llama.cpp)
+          ls -la llama.cpp/ggml/src/ggml-metal/ggml-metal.cpp
           ls -la llama.cpp/ggml/src/ggml-metal/ggml-metal.metal
 
       - name: Setup Zig


### PR DESCRIPTION
## Summary
- Update release workflow to check for `ggml-metal.cpp` instead of `ggml-metal.m`
- The llama.cpp submodule changed its file structure - the old `.m` file no longer exists

## Problem
The macOS Metal builds were failing at the "Verify Submodule Files" step because we were checking for `ggml-metal.m` which no longer exists in the current llama.cpp structure.

## Solution
The file structure in llama.cpp has changed:
- **Old**: `ggml-metal.m` (single file)
- **New**: `ggml-metal.cpp` + separate `.m` files (`ggml-metal-context.m`, `ggml-metal-device.m`)

This PR updates the verification step to check for the correct file.