### PR TITLE
fix: update examples for Zig 0.15 API and new llama.cpp memory API

### DIFF
--- a/build_llama.zig
+++ b/build_llama.zig
@@ -273,7 +273,13 @@ pub const Context = struct {
             metal_lib.linkFramework("AppKit");
             metal_lib.linkFramework("Metal");
             metal_lib.linkFramework("MetalKit");
-            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal.m" }), .flags = ctx.flags() });
+            // New llama.cpp metal file structure (multiple .cpp and .m files)
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal.cpp" }), .flags = ctx.flags() });
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal-common.cpp" }), .flags = ctx.flags() });
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal-device.cpp" }), .flags = ctx.flags() });
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal-ops.cpp" }), .flags = ctx.flags() });
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal-context.m" }), .flags = ctx.flags() });
+            metal_lib.addCSourceFile(.{ .file = ctx.path(&.{ "ggml", "src", "ggml-metal", "ggml-metal-device.m" }), .flags = ctx.flags() });
             const metal_files = [_][]const u8{
                 "ggml-metal.metal",
                 "ggml-metal-impl.h",

--- a/examples/streaming.zig
+++ b/examples/streaming.zig
@@ -30,9 +30,7 @@ pub fn run(alloc: std.mem.Allocator, args: Args) !void {
     // Suppress verbose logging
     llama.logSet(null, null);
 
-    const stdout = std.io.getStdOut().writer();
-
-    try stdout.print("Loading model...\n", .{});
+    std.debug.print("Loading model...\n", .{});
     const load_start = std.time.milliTimestamp();
 
     var mparams = Model.defaultParams();
@@ -52,7 +50,7 @@ pub fn run(alloc: std.mem.Allocator, args: Args) !void {
     defer ctx.deinit();
 
     const load_time = std.time.milliTimestamp() - load_start;
-    try stdout.print("Model loaded in {d:.2}s\n\n", .{@as(f64, @floatFromInt(load_time)) / 1000.0});
+    std.debug.print("Model loaded in {d:.2}s\n\n", .{@as(f64, @floatFromInt(load_time)) / 1000.0});
 
     // Setup sampler
     var sampler = llama.Sampler.initChain(.{ .no_perf = false });
@@ -68,9 +66,9 @@ pub fn run(alloc: std.mem.Allocator, args: Args) !void {
     try tokenizer.tokenize(vocab, args.prompt, false, true);
 
     const prompt_tokens = tokenizer.getTokens().len;
-    try stdout.print("Prompt: {s}\n", .{args.prompt});
-    try stdout.print("Prompt tokens: {d}\n", .{prompt_tokens});
-    try stdout.print("---\n", .{});
+    std.debug.print("Prompt: {s}\n", .{args.prompt});
+    std.debug.print("Prompt tokens: {d}\n", .{prompt_tokens});
+    std.debug.print("---\n", .{});
 
     // Generate with streaming
     var detokenizer = llama.Detokenizer.init(alloc);
@@ -97,7 +95,7 @@ pub fn run(alloc: std.mem.Allocator, args: Args) !void {
 
         // Stream the token
         const text = try detokenizer.detokenize(vocab, token);
-        try stdout.print("{s}", .{text});
+        std.debug.print("{s}", .{text});
         detokenizer.clearRetainingCapacity();
 
         // Prepare next batch
@@ -109,23 +107,23 @@ pub fn run(alloc: std.mem.Allocator, args: Args) !void {
     const decode_time = std.time.milliTimestamp() - decode_start;
     const total_time = std.time.milliTimestamp() - gen_start;
 
-    try stdout.print("\n\n", .{});
+    std.debug.print("\n\n", .{});
 
     // Show statistics
     if (args.show_stats) {
-        try stdout.print("---\n", .{});
-        try stdout.print("Statistics:\n", .{});
-        try stdout.print("  Prompt tokens:    {d}\n", .{prompt_tokens});
-        try stdout.print("  Generated tokens: {d}\n", .{generated_tokens});
-        try stdout.print("  Prefill time:     {d:.2}ms ({d:.2} tokens/sec)\n", .{
+        std.debug.print("---\n", .{});
+        std.debug.print("Statistics:\n", .{});
+        std.debug.print("  Prompt tokens:    {d}\n", .{prompt_tokens});
+        std.debug.print("  Generated tokens: {d}\n", .{generated_tokens});
+        std.debug.print("  Prefill time:     {d:.2}ms ({d:.2} tokens/sec)\n", .{
             @as(f64, @floatFromInt(prefill_time)),
             @as(f64, @floatFromInt(prompt_tokens)) / (@as(f64, @floatFromInt(prefill_time)) / 1000.0),
         });
-        try stdout.print("  Decode time:      {d:.2}ms ({d:.2} tokens/sec)\n", .{
+        std.debug.print("  Decode time:      {d:.2}ms ({d:.2} tokens/sec)\n", .{
             @as(f64, @floatFromInt(decode_time)),
             @as(f64, @floatFromInt(generated_tokens)) / (@as(f64, @floatFromInt(decode_time)) / 1000.0),
         });
-        try stdout.print("  Total time:       {d:.2}ms\n", .{@as(f64, @floatFromInt(total_time))});
+        std.debug.print("  Total time:       {d:.2}ms\n", .{@as(f64, @floatFromInt(total_time))});
     }
 }
 


### PR DESCRIPTION
## Summary

- Update embeddings.zig to use `getEmbeddingsIth()` instead of non-existent `getEmbeddingsSeq()`
- Update embeddings.zig and chat.zig to use new memory API: `ctx.getMemory().clear()` instead of deprecated `kvCacheClear()`
- Update chat.zig to use `deprecatedReader()` for stdin input (Zig 0.15 changed `File.reader()` API to require a buffer parameter)
- Update build_llama.zig to include new metal source files for the updated llama.cpp structure

## Testing

- Build succeeds locally on Windows with Zig 0.15.2
- All examples compile without errors