### PR TITLE
fix: link libcpp for Metal C++ source files

### DIFF
--- a/build_llama.zig
+++ b/build_llama.zig
@@ -269,6 +269,7 @@ pub const Context = struct {
             metal_lib.addIncludePath(ctx.path(&.{ "ggml", "include" }));
             metal_lib.addIncludePath(ctx.path(&.{ "ggml", "src" }));
             metal_lib.addIncludePath(ctx.path(&.{ "ggml", "src", "ggml-metal" }));
+            metal_lib.linkLibCpp(); // Required for C++ standard library headers in .cpp files
             metal_lib.linkFramework("Foundation");
             metal_lib.linkFramework("AppKit");
             metal_lib.linkFramework("Metal");


### PR DESCRIPTION
## Summary

The Metal backend now uses .cpp files that require C++ standard library headers like `<array>`. Add `linkLibCpp()` to the `metal_lib` to fix macOS Metal builds.

## Problem

Metal builds failing with:
```
./llama.cpp/ggml/src/ggml-impl.h:681:10: error: 'array' file not found
#include <array>
```

## Solution

Add `metal_lib.linkLibCpp()` to link the C++ standard library for the Metal library compilation.