### PR TITLE
fix: update Metal shader compilation flags

### DIFF
--- a/build_llama.zig
+++ b/build_llama.zig
@@ -286,8 +286,10 @@ pub const Context = struct {
                 "ggml-metal-impl.h",
             };
             // Compile the metal shader [requires xcode installed]
+            // Note: -g flag is not used as it causes segmentation fault during compile
+            // Note: -fno-inline is needed to pass tests with MTL_SHADER_VALIDATION=1
             const metal_compile = ctx.b.addSystemCommand(&.{
-                "xcrun", "-sdk", "macosx", "metal", "-fno-fast-math", "-g",
+                "xcrun", "-sdk", "macosx", "metal", "-O3", "-fno-fast-math", "-fno-inline",
                 "-I", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal" }), // Include path for ggml-common.h
                 "-c", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.metal" }),
                 "-o", ctx.b.pathJoin(&.{ ctx.b.install_path, "metal", "ggml-metal.air" }),


### PR DESCRIPTION
## Summary
- Remove `-g` flag that causes segmentation fault during Metal shader compile
- Add `-O3` optimization flag for release builds
- Add `-fno-inline` flag needed for Metal shader validation

## Root Cause
The Metal shader compilation was failing because the `-g` (debug) flag causes segmentation faults during shader compilation, as documented in llama.cpp's CMakeLists.txt.

## Reference
Based on llama.cpp/ggml/src/ggml-metal/CMakeLists.txt:
```cmake
# note: adding -g causes segmentation fault during compile
#set(XC_FLAGS -fno-fast-math -fno-inline -g)
set(XC_FLAGS -fno-fast-math -fno-inline)
```

## Testing
This should fix the Metal build failures on macOS in the release workflow.