### PR TITLE
docs: update stale documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ curl http://localhost:8080/v1/embeddings \
 | `serve stop` | Stop the running server |
 | `serve status` | Show server status |
 | `serve logs` | View server logs |
+| `serve logs --follow` | Tail server logs continuously |
 
 ## Configuration
 
@@ -318,6 +319,8 @@ igllama/
 
 - x86_64 Windows
 - x86_64 Linux (Ubuntu 22+)
+- x86_64 macOS
+- aarch64 macOS (Apple Silicon)
 
 ## Backend Support
 

--- a/docs/build-llama-server-through-zig.md
+++ b/docs/build-llama-server-through-zig.md
@@ -326,7 +326,7 @@ jobs:
       
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.15.0
       
       - name: Build server
         run: zig build -Dserver=true -Doptimize=ReleaseFast

--- a/docs/create-your-own-server-in-zig.md
+++ b/docs/create-your-own-server-in-zig.md
@@ -741,7 +741,7 @@ test "server responds to completion request" {
     defer server_thread.join();
     
     // Wait for server to start
-    std.time.sleep(100 * std.time.ns_per_ms);
+    std.Thread.sleep(100 * std.time.ns_per_ms);
     
     // Send request
     const address = try net.Address.parseIp("127.0.0.1", 8080);


### PR DESCRIPTION
## Summary

Updates outdated documentation to reflect current project state.

## Changes

- **README.md**: 
  - Added `serve logs --follow` command to serve subcommands table
  - Expanded tested platforms to include macOS (x86_64 and aarch64)

- **build-llama-server-through-zig.md**: 
  - Updated CI example Zig version from 0.14.0 to 0.15.0

- **create-your-own-server-in-zig.md**: 
  - Fixed `std.time.sleep` to `std.Thread.sleep` (API changed in Zig 0.15)