### PR TITLE
feat: enable library usage as Zig dependency + add source tarball to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,11 +242,55 @@ jobs:
           VERSION="${{ steps.version.outputs.VERSION }}"
           gh release upload "${VERSION}" "${ARCHIVE_NAME}.tar.gz" --clobber
 
+  # Create source tarball with submodules for use in zon dependencies
+  create-source-tarball:
+    name: Create Source Tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: source
+
+      - name: Determine Version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Source Tarball
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          ARCHIVE_NAME="igllama-${VERSION}-source"
+          
+          # Create tarball excluding VCS and build artifacts
+          tar -czf ${ARCHIVE_NAME}.tar.gz \
+            --exclude-vcs \
+            --exclude='.github' \
+            --exclude='zig-out' \
+            --exclude='zig-cache' \
+            --exclude='.zig-cache' \
+            --transform "s,^source,${ARCHIVE_NAME}," \
+            source
+          
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+
+      - name: Upload to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          gh release upload "${VERSION}" "${ARCHIVE_NAME}.tar.gz" --clobber --repo ${{ github.repository }}
+
   # Create checksums after all builds complete
   checksums:
     name: Generate Checksums
     runs-on: ubuntu-latest
-    needs: [build-release, build-macos-metal, build-macos-cpu]
+    needs: [build-release, build-macos-metal, build-macos-cpu, create-source-tarball]
     steps:
       - name: Determine Version
         id: version


### PR DESCRIPTION
## Summary

This PR enables igllama to be used as a Zig dependency and adds source tarball generation to releases.

### Build System Improvements (`build.zig`)
- Export `llama` module via `b.addModule()` instead of `b.createModule()` for downstream dependency usage
- Build and install `llama.cpp` library artifact for external linking

### Release Workflow Enhancements (`.github/workflows/release.yml`)
- Add `create-source-tarball` job for zon dependencies
- Use `--exclude-vcs` for proper submodule VCS exclusion
- Consistent naming: `igllama-${VERSION}-source.tar.gz`
- Exclude build artifacts (`zig-out`, `zig-cache`, `.zig-cache`)

### Usage

Downstream projects can now use igllama as a Zig dependency:

```zig
const igllama = b.dependency("igllama", .{
    .target = target,
    .optimize = optimize,
});
exe.root_module.addImport("llama", igllama.module("llama"));
exe.linkLibrary(igllama.artifact("llama.cpp"));
```

---

**Note:** This incorporates improvements from PR #31 with refinements (avoiding module duplication, proper VCS exclusion, consistent naming).