### PR TITLE
docs: update README timestamp for February 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ igllama run model.gguf -p "Hello" --gpu-layers -1
 
 MIT License - See [LICENSE](LICENSE) for details.
 
+---
+
+*Last updated: February 2026*
+
 ## Credits
 
 - [llama.cpp](https://github.com/ggerganov/llama.cpp) - The underlying inference engine


### PR DESCRIPTION
Minor documentation update to trigger CI for the new month (February 2026).