### PR TITLE
fix: add backlinks to showcase subpages and improve homepage navigation

### DIFF
--- a/website/content/index.smd
+++ b/website/content/index.smd
@@ -141,3 +141,10 @@ zig build -Doptimize=ReleaseFast
 ```
 
 [View Full Documentation](https://bkataru.github.io/igllama/docs/)
+
+## Learn More
+
+- [**Benchmark Showcase**](/showcase/) - Real-world performance benchmarks and case studies
+- [**igllama vs Ollama**](/comparison/) - Architecture comparison and use cases
+- [**Philosophy**](/philosophy/) - Why igllama exists and design principles
+- [**Architecture**](/architecture/) - Technical deep dive into the system

--- a/website/content/showcase/qwen35-35b.smd
+++ b/website/content/showcase/qwen35-35b.smd
@@ -6,6 +6,9 @@
 .date = "2026-03-02",
 ---
 
+[← Back to Benchmark Showcase](/showcase/)
+
+
 ## Why Qwen3.5 MoE Excels on CPU-Only Systems
 
 Qwen3.5-35B-A3B is a **Mixture of Experts (MoE)** model with 35 billion total parameters, but only **3 billion active parameters per inference step**. This sparse activation pattern means your CPU processes roughly the same FLOPs as a 3B dense model, but draws on 35B of knowledge. For CPU-only deployments with plenty of RAM, this architecture is uniquely efficient.

--- a/website/content/showcase/qwen35-small.smd
+++ b/website/content/showcase/qwen35-small.smd
@@ -6,6 +6,9 @@
 .date = "2026-03-02",
 ---
 
+[← Back to Benchmark Showcase](/showcase/)
+
+
 ## The New Qwen 3.5 Small Series 🚀
 
 On March 2, 2026, Alibaba released the **Qwen 3.5 Small Model Series**, specifically designed for efficient on-device and edge AI applications. These models feature native multimodality, a 262K context window, and advanced "thinking mode" capabilities.


### PR DESCRIPTION
## Summary

- Added backlinks to showcase subpages (qwen35-35b.smd, qwen35-small.smd) for better navigation
- Added "Learn More" section to homepage with links to showcase, comparison, philosophy, and architecture pages
- Improved UX by ensuring users can easily navigate between related pages

## Changes

- `website/content/showcase/qwen35-35b.smd`: Added backlink to main showcase hub
- `website/content/showcase/qwen35-small.smd`: Added backlink to main showcase hub
- `website/content/index.smd`: Added "Learn More" section with links to major pages

## Testing

- Built website successfully with `zig build`
- Verified generated HTML contains correct backlinks and navigation links