### PR TITLE
chore: bump version to v0.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ MIT License - See [LICENSE](LICENSE) for details.
 
 ---
 
-*Last updated: March 2026 - v0.3.7 release*
+*Last updated: March 2026 - v0.3.10 release*
 
 ## Credits
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .igllama,
-    .version = "0.3.8",
+    .version = "0.3.10",
     .paths = .{
         "",
         "src",

--- a/src/config.zig
+++ b/src/config.zig
@@ -763,7 +763,7 @@ pub const Config = struct {
 };
 
 /// Version information
-pub const version = "0.3.8";
+pub const version = "0.3.10";
 pub const app_name = "igllama";
 pub const app_description = "A Zig-based Ollama alternative for GGUF model management";
 
@@ -816,7 +816,7 @@ test "Config.getServerPidPath returns valid path" {
 }
 
 test "version and app_name constants are set" {
-    try std.testing.expectEqualStrings("0.3.8", version);
+    try std.testing.expectEqualStrings("0.3.10", version);
     try std.testing.expectEqualStrings("igllama", app_name);
     try std.testing.expect(default_server_port == 8080);
 }


### PR DESCRIPTION
## Summary

Version bump covering two releases since v0.3.8:

**v0.3.9** — grammar-constrained `json_mode`
- `response_format: {"type":"json_object"}` now wires a GBNF JSON grammar into the llama.cpp sampler chain
- Both streaming and non-streaming handlers support `json_mode`
- Fixed streaming use-after-free: grammar string lifetimes now properly managed

**v0.3.10** — accurate `usage` token counts
- `handleCompletion()` now returns `CompletionResult{content, prompt_tokens, completion_tokens}`
- Non-streaming response `usage` field reports real token counts instead of hardcoded zeros
- `prompt_tokens` from tokenizer; `completion_tokens` from generation loop counter

## Changes
- `src/config.zig`: version `"0.3.8"` → `"0.3.10"`, test assertion updated
- `build.zig.zon`: version `"0.3.8"` → `"0.3.10"`
- `README.md`: last updated line updated to v0.3.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)